### PR TITLE
Add missing quotes for string enum values

### DIFF
--- a/json2/encode.v
+++ b/json2/encode.v
@@ -277,6 +277,7 @@ fn (mut encoder Encoder) encode_enum[T](val T) {
 			
 			enum_val = enum_val[i + 1..enum_val.len - 1]
 		}
+		enum_val = '"' + enum_val + '"'
 		unsafe { encoder.output.push_many(enum_val.str, enum_val.len) }
 	}
 }


### PR DESCRIPTION
Before:
```
"ccompiler_type":gcc
```
After:
```
"ccompiler_type":"gcc"
```